### PR TITLE
fix ignored DefaultTemplate

### DIFF
--- a/src/stone.ml
+++ b/src/stone.ml
@@ -81,7 +81,7 @@ let build_folder folder =
           ) conf.Conf.pages_templates
           |> snd
         with
-          Not_found -> default_template in
+          Not_found -> conf.default_template in
       let template_str = List.assoc template_filename templates_str in
 
       Gen.page folder template_str conf targets page)


### PR DESCRIPTION
Hi,

This is a fix for #10. I tested it and it works. :)

If the file doesn't exist we'll get an ugly:

```sh
Fatal error: exception Not_found
```

What was done before was that `template.html` was always used as a default. So we could add it again as a fallback in case the user provided default doesn't exist; or we could just add a better error message.

Cheers.